### PR TITLE
Fix internal module loading on non-windows platforms

### DIFF
--- a/PlanformCreator2.py
+++ b/PlanformCreator2.py
@@ -34,11 +34,11 @@ from PyQt6.QtGui            import QCloseEvent, QGuiApplication
 
 # let python find the other modules in modules relativ to path of self -
 # common modules hosted by AirfoilEditor  ! before python system modules and PlanformCreator path 
-sys.path.insert (1,os.path.join(Path(__file__).parent , 'AirfoilEditor_subtree\\modules'))
+sys.path.insert (1,os.path.join(Path(__file__).parent , 'AirfoilEditor_subtree', 'modules'))
 
 # local modules - at the end - AirfoilEditor modules do have precedence
 sys.path.append (os.path.join(Path(__file__).parent , 'modules'))
-sys.path.append (os.path.join(Path(__file__).parent , 'modules\\wing_model'))
+sys.path.append (os.path.join(Path(__file__).parent , 'modules', 'wing_model'))
 from wing                   import Wing
 
 from base.common_utils      import * 

--- a/PlanformCreator2.py
+++ b/PlanformCreator2.py
@@ -34,11 +34,12 @@ from PyQt6.QtGui            import QCloseEvent, QGuiApplication
 
 # let python find the other modules in modules relativ to path of self -
 # common modules hosted by AirfoilEditor  ! before python system modules and PlanformCreator path 
-sys.path.insert (1,os.path.join(Path(__file__).parent , 'AirfoilEditor_subtree', 'modules'))
+sys.path.insert (1, str(Path(__file__).parent / 'AirfoilEditor_subtree' / 'modules'))
 
 # local modules - at the end - AirfoilEditor modules do have precedence
-sys.path.append (os.path.join(Path(__file__).parent , 'modules'))
-sys.path.append (os.path.join(Path(__file__).parent , 'modules', 'wing_model'))
+sys.path.append(str(Path(__file__).parent / 'modules'))
+sys.path.append(str(Path(__file__).parent / 'modules' / 'wing_model'))
+
 from wing                   import Wing
 
 from base.common_utils      import * 


### PR DESCRIPTION
As described in the commit messages this fixes loading of the internal modules on platforms that don't use a backslash (`\`) for directory separation. Using this I was able to test the new amazing version on Linux. As always, thank you for your enduring efforts.